### PR TITLE
style: format code with black and remove whitespace

### DIFF
--- a/benches/markdown_bench.rs
+++ b/benches/markdown_bench.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use markdown_lab_rs::{
     chunker::create_semantic_chunks,
     html_parser::{clean_html, extract_links, extract_main_content},

--- a/markdown_lab/core/rust_backend.py
+++ b/markdown_lab/core/rust_backend.py
@@ -49,15 +49,15 @@ class RustBackend:
     ) -> str:
         """
         Converts HTML content to the specified output format using the Rust backend.
-        
+
         Parameters:
             html (str): The HTML content to convert.
             base_url (str): The base URL used to resolve relative links in the HTML.
             output_format (str, optional): The desired output format ("markdown", "json", or "xml"). Defaults to "markdown".
-        
+
         Returns:
             str: The converted content in the specified format.
-        
+
         Raises:
             RustIntegrationError: If the Rust backend is unavailable or the conversion fails.
         """

--- a/markdown_lab/network/client.py
+++ b/markdown_lab/network/client.py
@@ -251,13 +251,13 @@ class CachedHttpClient(HttpClient):
     def get(self, url: str, use_cache: bool = True, **kwargs) -> str:
         """
         Retrieve the content of a URL using a GET request, utilizing cache if enabled.
-        
+
         If caching is enabled and a cached response exists for the URL, returns the cached content. Otherwise, performs the GET request, stores the result in the cache if applicable, and returns the response content.
-        
+
         Parameters:
             url (str): The URL to fetch.
             use_cache (bool): Whether to use and update the cache for this request.
-        
+
         Returns:
             str: The response body as text.
         """

--- a/tests/rust/test_rust_backend.py
+++ b/tests/rust/test_rust_backend.py
@@ -1,18 +1,19 @@
-import pytest
-import unittest.mock as mock
-from unittest.mock import patch, MagicMock, call
-import tempfile
 import os
-import sys
-from pathlib import Path
 import subprocess
-import json
-import time
+import sys
+import tempfile
 import threading
-from typing import Dict, Any, List
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'git'))
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "git"))
+import contextlib
+
 from markdown_lab.core.rust_backend import RustBackend, get_rust_backend
+
 
 @pytest.fixture
 def rust_backend():
@@ -20,8 +21,9 @@ def rust_backend():
     backend = RustBackend()
     yield backend
     # Cleanup after test
-    if hasattr(backend, 'cleanup'):
+    if hasattr(backend, "cleanup"):
         backend.cleanup()
+
 
 @pytest.fixture
 def temp_dir():
@@ -29,31 +31,34 @@ def temp_dir():
     with tempfile.TemporaryDirectory() as tmpdir:
         yield Path(tmpdir)
 
+
 @pytest.fixture
 def sample_rust_code():
     """Sample valid Rust code for testing."""
-    return '''
+    return """
 fn main() {
     println!("Hello, world!");
     let x = 42;
     println!("The answer is: {}", x);
 }
-'''
+"""
+
 
 @pytest.fixture
 def invalid_rust_code():
     """Invalid Rust code for testing error handling."""
-    return '''
+    return """
 fn main() {
     println!("Hello, world!"  // Missing semicolon and closing paren
     let x = ;  // Invalid assignment
 }
-'''
+"""
+
 
 @pytest.fixture
 def complex_rust_code():
     """More complex Rust code for advanced testing."""
-    return '''
+    return """
 use std::collections::HashMap;
 
 struct Person {
@@ -84,7 +89,8 @@ fn main() {
         person.greet();
     }
 }
-'''
+"""
+
 
 @pytest.fixture
 def mock_subprocess_success():
@@ -95,6 +101,7 @@ def mock_subprocess_success():
     mock_result.stderr = ""
     return mock_result
 
+
 @pytest.fixture
 def mock_subprocess_failure():
     """Mock failed subprocess execution."""
@@ -104,6 +111,7 @@ def mock_subprocess_failure():
     mock_result.stderr = "Compilation failed"
     return mock_result
 
+
 class TestRustBackendHappyPath:
     """Test cases for successful rust backend operations."""
 
@@ -111,8 +119,8 @@ class TestRustBackendHappyPath:
         """Test that RustBackend initializes correctly."""
         backend = RustBackend()
         assert backend is not None
-        assert hasattr(backend, '__class__')
-        assert backend.__class__.__name__ == 'RustBackend'
+        assert hasattr(backend, "__class__")
+        assert backend.__class__.__name__ == "RustBackend"
 
     def test_get_rust_backend_function(self):
         """Test the get_rust_backend factory function."""
@@ -127,51 +135,66 @@ class TestRustBackendHappyPath:
         assert backend1 is not None
         assert backend2 is not None
 
-    @patch('subprocess.run')
-    def test_successful_rust_compilation(self, mock_run, rust_backend, sample_rust_code, temp_dir, mock_subprocess_success):
+    @patch("subprocess.run")
+    def test_successful_rust_compilation(
+        self,
+        mock_run,
+        rust_backend,
+        sample_rust_code,
+        temp_dir,
+        mock_subprocess_success,
+    ):
         """Test successful compilation of valid Rust code."""
         mock_run.return_value = mock_subprocess_success
 
         source_file = temp_dir / "main.rs"
         source_file.write_text(sample_rust_code)
 
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             result = rust_backend.compile(str(source_file))
             assert result is not None
-        elif hasattr(rust_backend, 'process'):
+        elif hasattr(rust_backend, "process"):
             result = rust_backend.process(str(source_file))
             assert result is not None
 
-    @patch('subprocess.run')
-    def test_rust_backend_with_complex_code(self, mock_run, rust_backend, complex_rust_code, temp_dir, mock_subprocess_success):
+    @patch("subprocess.run")
+    def test_rust_backend_with_complex_code(
+        self,
+        mock_run,
+        rust_backend,
+        complex_rust_code,
+        temp_dir,
+        mock_subprocess_success,
+    ):
         """Test rust backend with more complex Rust code."""
         mock_run.return_value = mock_subprocess_success
 
         source_file = temp_dir / "complex.rs"
         source_file.write_text(complex_rust_code)
 
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             result = rust_backend.compile(str(source_file))
             assert result is not None
 
     def test_rust_backend_configuration(self, rust_backend):
         """Test rust backend configuration and settings."""
-        if hasattr(rust_backend, 'get_config'):
+        if hasattr(rust_backend, "get_config"):
             config = rust_backend.get_config()
             assert config is not None
-        if hasattr(rust_backend, 'set_config'):
+        if hasattr(rust_backend, "set_config"):
             test_config = {"debug": True, "optimize": False}
             rust_backend.set_config(test_config)
 
     def test_rust_backend_version_info(self, rust_backend):
         """Test rust backend version information."""
-        if hasattr(rust_backend, 'version'):
+        if hasattr(rust_backend, "version"):
             version = rust_backend.version()
             assert version is not None
             assert isinstance(version, str)
-        if hasattr(rust_backend, 'rust_version'):
+        if hasattr(rust_backend, "rust_version"):
             rust_version = rust_backend.rust_version()
             assert rust_version is not None
+
 
 class TestRustBackendEdgeCases:
     """Test edge cases and boundary conditions."""
@@ -181,7 +204,7 @@ class TestRustBackendEdgeCases:
         source_file = temp_dir / "empty.rs"
         source_file.write_text("")
 
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             try:
                 result = rust_backend.compile(str(source_file))
                 assert result is not None
@@ -199,7 +222,7 @@ class TestRustBackendEdgeCases:
         source_file = temp_dir / "large.rs"
         source_file.write_text(large_code)
 
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             try:
                 result = rust_backend.compile(str(source_file))
                 assert result is not None
@@ -208,18 +231,18 @@ class TestRustBackendEdgeCases:
 
     def test_rust_file_with_unicode_content(self, rust_backend, temp_dir):
         """Test handling of Rust files with Unicode characters."""
-        unicode_code = '''
+        unicode_code = """
 fn main() {
     println!("Hello, 世界! 🦀");
     println!("Rust with émojis: 🚀 and äccénts");
     let 变量 = "Unicode variable names";
     println!("{}", 变量);
 }
-'''
+"""
         source_file = temp_dir / "unicode.rs"
-        source_file.write_text(unicode_code, encoding='utf-8')
+        source_file.write_text(unicode_code, encoding="utf-8")
 
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             try:
                 result = rust_backend.compile(str(source_file))
                 assert result is not None
@@ -234,14 +257,16 @@ fn main() {
             special_dir.mkdir()
             source_file = special_dir / "main.rs"
             source_file.write_text("fn main() { println!('Hello'); }")
-            if hasattr(rust_backend, 'compile'):
+            if hasattr(rust_backend, "compile"):
                 try:
                     result = rust_backend.compile(str(source_file))
                     assert result is not None
                 except Exception:
                     pass
 
-    def test_concurrent_rust_backend_usage(self, rust_backend, sample_rust_code, temp_dir):
+    def test_concurrent_rust_backend_usage(
+        self, rust_backend, sample_rust_code, temp_dir
+    ):
         """Test concurrent usage of rust backend."""
         results = []
         errors = []
@@ -250,7 +275,7 @@ fn main() {
             try:
                 source_file = temp_dir / f"main_{thread_id}.rs"
                 source_file.write_text(sample_rust_code)
-                if hasattr(rust_backend, 'compile'):
+                if hasattr(rust_backend, "compile"):
                     result = rust_backend.compile(str(source_file))
                     results.append((thread_id, result))
             except Exception as e:
@@ -267,36 +292,39 @@ fn main() {
 
     def test_rust_backend_with_very_long_lines(self, rust_backend, temp_dir):
         """Test handling of Rust files with very long lines."""
-        very_long_line = "fn main() { " + "println!(\"" + "x" * 10000 + "\"); }"
+        very_long_line = "fn main() { " + 'println!("' + "x" * 10000 + '"); }'
         source_file = temp_dir / "long_lines.rs"
         source_file.write_text(very_long_line)
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             try:
                 result = rust_backend.compile(str(source_file))
                 assert result is not None
             except Exception:
                 pass
 
+
 class TestRustBackendFailureConditions:
     """Test failure conditions and error handling."""
 
     def test_nonexistent_file_handling(self, rust_backend):
         """Test handling of non-existent files."""
-        nonexistent_file = "/definitely/does/not/exist/file.rs"
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
+            nonexistent_file = "/definitely/does/not/exist/file.rs"
             with pytest.raises((FileNotFoundError, IOError, ValueError, Exception)):
                 rust_backend.compile(nonexistent_file)
 
-    def test_invalid_rust_syntax_handling(self, rust_backend, invalid_rust_code, temp_dir):
+    def test_invalid_rust_syntax_handling(
+        self, rust_backend, invalid_rust_code, temp_dir
+    ):
         """Test handling of invalid Rust syntax."""
         source_file = temp_dir / "invalid.rs"
         source_file.write_text(invalid_rust_code)
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             try:
                 result = rust_backend.compile(str(source_file))
-                if hasattr(result, 'success'):
+                if hasattr(result, "success"):
                     assert not result.success
-                elif hasattr(result, 'error'):
+                elif hasattr(result, "error"):
                     assert result.error is not None
             except Exception as e:
                 assert e is not None
@@ -307,41 +335,50 @@ class TestRustBackendFailureConditions:
         source_file.write_text(sample_rust_code)
         os.chmod(source_file, 0o000)
         try:
-            if hasattr(rust_backend, 'compile'):
+            if hasattr(rust_backend, "compile"):
                 with pytest.raises((PermissionError, IOError, Exception)):
                     rust_backend.compile(str(source_file))
         finally:
             os.chmod(source_file, 0o644)
 
-    @patch('subprocess.run')
-    def test_subprocess_failure_handling(self, mock_run, rust_backend, sample_rust_code, temp_dir, mock_subprocess_failure):
+    @patch("subprocess.run")
+    def test_subprocess_failure_handling(
+        self,
+        mock_run,
+        rust_backend,
+        sample_rust_code,
+        temp_dir,
+        mock_subprocess_failure,
+    ):
         """Test handling of subprocess failures."""
         mock_run.return_value = mock_subprocess_failure
         source_file = temp_dir / "main.rs"
         source_file.write_text(sample_rust_code)
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             try:
                 result = rust_backend.compile(str(source_file))
-                if hasattr(result, 'success'):
+                if hasattr(result, "success"):
                     assert not result.success
-                elif hasattr(result, 'error'):
+                elif hasattr(result, "error"):
                     assert result.error is not None
             except Exception as e:
                 assert e is not None
 
-    @patch('subprocess.run')
-    def test_subprocess_timeout_handling(self, mock_run, rust_backend, sample_rust_code, temp_dir):
+    @patch("subprocess.run")
+    def test_subprocess_timeout_handling(
+        self, mock_run, rust_backend, sample_rust_code, temp_dir
+    ):
         """Test handling of subprocess timeouts."""
         mock_run.side_effect = subprocess.TimeoutExpired("rustc", 10)
         source_file = temp_dir / "main.rs"
         source_file.write_text(sample_rust_code)
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             with pytest.raises((subprocess.TimeoutExpired, Exception)):
                 rust_backend.compile(str(source_file))
 
     def test_invalid_configuration_handling(self, rust_backend):
         """Test handling of invalid configuration."""
-        if hasattr(rust_backend, 'set_config'):
+        if hasattr(rust_backend, "set_config"):
             invalid_configs = [
                 None,
                 "invalid_string",
@@ -353,54 +390,72 @@ class TestRustBackendFailureConditions:
             for cfg in invalid_configs:
                 try:
                     rust_backend.set_config(cfg)
-                except (ValueError, TypeError, Exception) as e:
+                except Exception as e:
                     assert e is not None
 
     def test_rust_backend_after_disposal(self, rust_backend):
         """Test rust backend behavior after disposal/cleanup."""
-        if hasattr(rust_backend, 'dispose'):
+        if hasattr(rust_backend, "dispose"):
             rust_backend.dispose()
-            if hasattr(rust_backend, 'compile'):
+            if hasattr(rust_backend, "compile"):
                 with pytest.raises(Exception):
                     rust_backend.compile("dummy.rs")
 
     def test_multiple_disposal_calls(self, rust_backend):
         """Test multiple disposal calls don't cause issues."""
-        if hasattr(rust_backend, 'dispose'):
+        if hasattr(rust_backend, "dispose"):
             rust_backend.dispose()
             rust_backend.dispose()
             rust_backend.dispose()
+
 
 class TestRustBackendMocking:
     """Test rust backend with mocked external dependencies."""
 
-    @patch('subprocess.run')
-    @patch('os.path.exists')
-    def test_mocked_file_operations(self, mock_exists, mock_run, rust_backend, mock_subprocess_success):
+    @patch("subprocess.run")
+    @patch("os.path.exists")
+    def test_mocked_file_operations(
+        self, mock_exists, mock_run, rust_backend, mock_subprocess_success
+    ):
         """Test file operations with mocked dependencies."""
         mock_exists.return_value = True
         mock_run.return_value = mock_subprocess_success
-        if hasattr(rust_backend, 'compile'):
-            result = rust_backend.compile("/fake/path/main.rs")
+        if hasattr(rust_backend, "compile"):
+            rust_backend.compile("/fake/path/main.rs")
             mock_exists.assert_called()
             mock_run.assert_called()
 
-    @patch('subprocess.run')
-    def test_mocked_rustc_command_structure(self, mock_run, rust_backend, sample_rust_code, temp_dir, mock_subprocess_success):
+    @patch("subprocess.run")
+    def test_mocked_rustc_command_structure(
+        self,
+        mock_run,
+        rust_backend,
+        sample_rust_code,
+        temp_dir,
+        mock_subprocess_success,
+    ):
         """Test that rustc is called with correct command structure."""
         mock_run.return_value = mock_subprocess_success
         source_file = temp_dir / "main.rs"
         source_file.write_text(sample_rust_code)
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             rust_backend.compile(str(source_file))
             mock_run.assert_called()
-            call_args = mock_run.call_args
-            if call_args:
-                cmd = call_args[0][0] if isinstance(call_args[0], (list, tuple)) else call_args[0]
-                assert any('rustc' in str(arg) for arg in (cmd if isinstance(cmd, (list, tuple)) else [cmd]))
+            if call_args := mock_run.call_args:
+                cmd = (
+                    call_args[0][0]
+                    if isinstance(call_args[0], (list, tuple))
+                    else call_args[0]
+                )
+                assert any(
+                    "rustc" in str(arg)
+                    for arg in (cmd if isinstance(cmd, (list, tuple)) else [cmd])
+                )
 
-    @patch('subprocess.Popen')
-    def test_mocked_streaming_output(self, mock_popen, rust_backend, sample_rust_code, temp_dir):
+    @patch("subprocess.Popen")
+    def test_mocked_streaming_output(
+        self, mock_popen, rust_backend, sample_rust_code, temp_dir
+    ):
         """Test streaming output handling with mocked Popen."""
         mock_process = MagicMock()
         mock_process.stdout.readline.side_effect = [b"Line 1\n", b"Line 2\n", b""]
@@ -410,50 +465,55 @@ class TestRustBackendMocking:
         mock_popen.return_value = mock_process
         source_file = temp_dir / "main.rs"
         source_file.write_text(sample_rust_code)
-        if hasattr(rust_backend, 'compile_with_streaming'):
-            result = rust_backend.compile_with_streaming(str(source_file))
+        if hasattr(rust_backend, "compile_with_streaming"):
+            rust_backend.compile_with_streaming(str(source_file))
             mock_popen.assert_called()
 
-    @patch('os.environ')
-    def test_mocked_environment_variables(self, mock_env, rust_backend, sample_rust_code, temp_dir):
+    @patch("os.environ")
+    def test_mocked_environment_variables(
+        self, mock_env, rust_backend, sample_rust_code, temp_dir
+    ):
         """Test environment variable handling."""
         mock_env.copy.return_value = {
-            'PATH': '/usr/bin',
-            'RUST_BACKTRACE': '1',
-            'RUSTFLAGS': '-C opt-level=2',
+            "PATH": "/usr/bin",
+            "RUST_BACKTRACE": "1",
+            "RUSTFLAGS": "-C opt-level=2",
         }
         source_file = temp_dir / "main.rs"
         source_file.write_text(sample_rust_code)
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             try:
                 rust_backend.compile(str(source_file))
                 mock_env.copy.assert_called()
             except Exception:
                 pass
 
-    @patch('tempfile.mkdtemp')
-    def test_mocked_temporary_directory_creation(self, mock_mkdtemp, rust_backend, sample_rust_code, temp_dir):
+    @patch("tempfile.mkdtemp")
+    def test_mocked_temporary_directory_creation(
+        self, mock_mkdtemp, rust_backend, sample_rust_code, temp_dir
+    ):
         """Test temporary directory creation with mocking."""
         mock_mkdtemp.return_value = str(temp_dir / "rust_temp")
         source_file = temp_dir / "main.rs"
         source_file.write_text(sample_rust_code)
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             try:
                 rust_backend.compile(str(source_file))
                 assert mock_mkdtemp.called
             except Exception:
                 pass
 
-    @patch('shutil.which')
+    @patch("shutil.which")
     def test_mocked_executable_detection(self, mock_which, rust_backend):
         """Test executable detection with mocking."""
         mock_which.return_value = "/usr/bin/rustc"
-        if hasattr(rust_backend, 'check_rustc_available'):
+        if hasattr(rust_backend, "check_rustc_available"):
             assert rust_backend.check_rustc_available() is True
-            mock_which.assert_called_with('rustc')
+            mock_which.assert_called_with("rustc")
         mock_which.return_value = None
-        if hasattr(rust_backend, 'check_rustc_available'):
+        if hasattr(rust_backend, "check_rustc_available"):
             assert rust_backend.check_rustc_available() is False
+
 
 class TestRustBackendPerformanceAndResources:
     """Test performance characteristics and resource management."""
@@ -461,11 +521,12 @@ class TestRustBackendPerformanceAndResources:
     def test_memory_usage_monitoring(self, rust_backend, sample_rust_code, temp_dir):
         """Test memory usage during compilation."""
         import psutil
+
         process = psutil.Process(os.getpid())
         initial_memory = process.memory_info().rss
         source_file = temp_dir / "main.rs"
         source_file.write_text(sample_rust_code)
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             try:
                 rust_backend.compile(str(source_file))
                 peak_memory = process.memory_info().rss
@@ -478,7 +539,7 @@ class TestRustBackendPerformanceAndResources:
 
     def test_compilation_timeout_handling(self, rust_backend, temp_dir):
         """Test compilation timeout handling."""
-        complex_code = '''
+        complex_code = """
         macro_rules! recursive_macro {
             (0) => { 1 };
             ($n:expr) => { $n * recursive_macro!($n - 1) };
@@ -487,22 +548,26 @@ class TestRustBackendPerformanceAndResources:
             let result = recursive_macro!(20);
             println!("Result: {}", result);
         }
-        '''
+        """
         source_file = temp_dir / "complex.rs"
         source_file.write_text(complex_code)
-        if hasattr(rust_backend, 'compile_with_timeout'):
+        if hasattr(rust_backend, "compile_with_timeout"):
             try:
-                result = rust_backend.compile_with_timeout(str(source_file), timeout=0.1)
+                result = rust_backend.compile_with_timeout(
+                    str(source_file), timeout=0.1
+                )
                 assert result is not None
             except Exception as e:
                 assert "timeout" in str(e).lower()
 
-    def test_multiple_sequential_compilations(self, rust_backend, sample_rust_code, temp_dir):
+    def test_multiple_sequential_compilations(
+        self, rust_backend, sample_rust_code, temp_dir
+    ):
         """Test multiple sequential compilations for memory leaks."""
         for i in range(10):
             source_file = temp_dir / f"main_{i}.rs"
             source_file.write_text(sample_rust_code)
-            if hasattr(rust_backend, 'compile'):
+            if hasattr(rust_backend, "compile"):
                 try:
                     result = rust_backend.compile(str(source_file))
                     assert result is not None
@@ -511,56 +576,59 @@ class TestRustBackendPerformanceAndResources:
 
     def test_large_output_handling(self, rust_backend, temp_dir):
         """Test handling of programs that produce large output."""
-        large_output_code = '''
+        large_output_code = """
         fn main() {
             for i in 0..10000 {
                 println!("Output line number: {}", i);
             }
         }
-        '''
+        """
         source_file = temp_dir / "large_output.rs"
         source_file.write_text(large_output_code)
-        if hasattr(rust_backend, 'compile_and_run'):
+        if hasattr(rust_backend, "compile_and_run"):
             try:
                 result = rust_backend.compile_and_run(str(source_file))
-                if hasattr(result, 'output'):
+                if hasattr(result, "output"):
                     assert len(result.output) < 10 * 1024 * 1024
             except Exception:
                 pass
 
-    def test_resource_cleanup_after_errors(self, rust_backend, invalid_rust_code, temp_dir):
+    def test_resource_cleanup_after_errors(
+        self, rust_backend, invalid_rust_code, temp_dir
+    ):
         """Test resource cleanup after compilation errors."""
         source_file = temp_dir / "invalid.rs"
         source_file.write_text(invalid_rust_code)
         initial_files = len(list(temp_dir.glob("*")))
-        if hasattr(rust_backend, 'compile'):
-            try:
+        if hasattr(rust_backend, "compile"):
+            with contextlib.suppress(Exception):
                 rust_backend.compile(str(source_file))
-            except Exception:
-                pass
-        if hasattr(rust_backend, 'cleanup'):
+        if hasattr(rust_backend, "cleanup"):
             rust_backend.cleanup()
         final_files = len(list(temp_dir.glob("*")))
         assert final_files <= initial_files + 1
 
+
 class TestRustBackendCleanupAndIntegration:
     """Test cleanup, resource management, and integration scenarios."""
 
-    def test_proper_cleanup_after_successful_compilation(self, rust_backend, sample_rust_code, temp_dir):
+    def test_proper_cleanup_after_successful_compilation(
+        self, rust_backend, sample_rust_code, temp_dir
+    ):
         """Test cleanup after successful compilation."""
         source_file = temp_dir / "main.rs"
         source_file.write_text(sample_rust_code)
         initial_files = set(temp_dir.rglob("*"))
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             try:
                 _ = rust_backend.compile(str(source_file))
-                if hasattr(rust_backend, 'cleanup'):
+                if hasattr(rust_backend, "cleanup"):
                     rust_backend.cleanup()
                 final_files = set(temp_dir.rglob("*"))
                 extra = final_files - initial_files
                 assert len(extra) <= 1
             except Exception:
-                if hasattr(rust_backend, 'cleanup'):
+                if hasattr(rust_backend, "cleanup"):
                     rust_backend.cleanup()
 
     def test_context_manager_support(self, sample_rust_code, temp_dir):
@@ -569,7 +637,7 @@ class TestRustBackendCleanupAndIntegration:
         source_file.write_text(sample_rust_code)
         try:
             with RustBackend() as backend:
-                if hasattr(backend, 'compile'):
+                if hasattr(backend, "compile"):
                     result = backend.compile(str(source_file))
                     assert result is not None
         except TypeError:
@@ -579,63 +647,75 @@ class TestRustBackendCleanupAndIntegration:
         """Test backend state remains consistent across operations."""
         source_file = temp_dir / "main.rs"
         source_file.write_text(sample_rust_code)
-        if hasattr(rust_backend, 'is_ready'):
+        if hasattr(rust_backend, "is_ready"):
             initial_ready = rust_backend.is_ready()
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             try:
                 _ = rust_backend.compile(str(source_file))
-                if hasattr(rust_backend, 'is_ready'):
+                if hasattr(rust_backend, "is_ready"):
                     assert rust_backend.is_ready() == initial_ready
             except Exception:
-                if hasattr(rust_backend, 'is_ready'):
+                if hasattr(rust_backend, "is_ready"):
                     assert isinstance(rust_backend.is_ready(), bool)
 
-    def test_integration_with_real_rust_environment(self, rust_backend, sample_rust_code, temp_dir):
+    def test_integration_with_real_rust_environment(
+        self, rust_backend, sample_rust_code, temp_dir
+    ):
         """Integration test with real Rust environment if available."""
         import shutil
-        if shutil.which('rustc') is None:
+
+        if shutil.which("rustc") is None:
             pytest.skip("rustc not available for integration testing")
         source_file = temp_dir / "integration_test.rs"
         source_file.write_text(sample_rust_code)
-        if hasattr(rust_backend, 'compile'):
+        if hasattr(rust_backend, "compile"):
             try:
                 result = rust_backend.compile(str(source_file))
                 assert result is not None
-                if getattr(result, 'success', False) and hasattr(result, 'executable_path'):
+                if getattr(result, "success", False) and hasattr(
+                    result, "executable_path"
+                ):
                     assert Path(result.executable_path).exists()
             except Exception as e:
                 pytest.skip(f"Integration test failed due to environment: {e}")
+
 
 def setup_module(module):
     """Set up module-level resources."""
     test_dir = Path("test_artifacts")
     test_dir.mkdir(exist_ok=True)
 
+
 def teardown_module(module):
     """Clean up module-level resources."""
     import shutil
+
     test_dir = Path("test_artifacts")
     if test_dir.exists():
         shutil.rmtree(test_dir, ignore_errors=True)
 
-@pytest.mark.parametrize("rust_code,expected_behavior", [
-    ("fn main() {}", "simple_success"),
-    ("fn main() { panic!(\"test\"); }", "runtime_panic"),
-    ("invalid rust code", "compile_error"),
-    ("fn main() { loop {} }", "infinite_loop"),
-])
+
+@pytest.mark.parametrize(
+    "rust_code,expected_behavior",
+    [
+        ("fn main() {}", "simple_success"),
+        ('fn main() { panic!("test"); }', "runtime_panic"),
+        ("invalid rust code", "compile_error"),
+        ("fn main() { loop {} }", "infinite_loop"),
+    ],
+)
 def test_parametrized_rust_code_scenarios(rust_code, expected_behavior, temp_dir):
     """Parametrized tests for different Rust code scenarios."""
     backend = RustBackend()
     source_file = temp_dir / f"{expected_behavior}.rs"
     source_file.write_text(rust_code)
-    if hasattr(backend, 'compile'):
+    if hasattr(backend, "compile"):
         try:
             result = backend.compile(str(source_file))
             if expected_behavior == "simple_success":
                 assert result is not None
             elif expected_behavior == "compile_error":
-                if hasattr(result, 'success'):
+                if hasattr(result, "success"):
                     assert not result.success
         except Exception as e:
             if expected_behavior in ["compile_error", "runtime_panic"]:
@@ -643,11 +723,12 @@ def test_parametrized_rust_code_scenarios(rust_code, expected_behavior, temp_dir
             else:
                 pytest.fail(f"Unexpected exception for {expected_behavior}: {e}")
 
+
 @pytest.mark.slow
 def test_compilation_performance_benchmark(temp_dir):
     """Benchmark compilation performance (marked as slow test)."""
-    import time
-    rust_code = '''
+
+    rust_code = """
     fn fibonacci(n: u32) -> u32 {
         match n {
             0 => 0,
@@ -660,11 +741,11 @@ def test_compilation_performance_benchmark(temp_dir):
             println!("fib({}) = {}", i, fibonacci(i));
         }
     }
-    '''
+    """
     backend = RustBackend()
     source_file = temp_dir / "benchmark.rs"
     source_file.write_text(rust_code)
-    if hasattr(backend, 'compile'):
+    if hasattr(backend, "compile"):
         start = time.time()
         try:
             _ = backend.compile(str(source_file))

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,13 +1,12 @@
-import pytest
-from unittest.mock import Mock, patch, MagicMock, call
-import requests
-from requests.exceptions import RequestException, Timeout, ConnectionError
-import json
 import time
-from typing import Optional, Dict, Any
+from unittest.mock import Mock, patch
+
+import pytest
+from requests.exceptions import ConnectionError, RequestException, Timeout
 
 from markdown_lab.core.client import CoreClient
 from markdown_lab.network.client import NetworkClient
+
 
 @pytest.fixture
 def mock_response():
@@ -19,20 +18,24 @@ def mock_response():
     mock_resp.headers = {"content-type": "text/html"}
     return mock_resp
 
+
 @pytest.fixture
 def core_client():
     """Fixture for CoreClient instance."""
     return CoreClient()
+
 
 @pytest.fixture
 def network_client():
     """Fixture for NetworkClient instance."""
     return NetworkClient()
 
+
 @pytest.fixture
 def sample_html():
     """Sample HTML content for testing."""
     return "<html><head><title>Test</title></head><body><h1>Header</h1><p>Paragraph</p></body></html>"
+
 
 @pytest.fixture
 def sample_config():
@@ -41,181 +44,197 @@ def sample_config():
         "timeout": 30,
         "retries": 3,
         "user_agent": "MarkdownLab/1.0",
-        "headers": {"Accept": "text/html,application/xhtml+xml"}
+        "headers": {"Accept": "text/html,application/xhtml+xml"},
     }
+
 
 class TestCoreClient:
     """Test suite for CoreClient functionality."""
-    
+
     def test_core_client_initialization_default(self):
         """Test CoreClient initializes with default parameters."""
         client = CoreClient()
         assert client is not None
-        assert hasattr(client, 'config')
-        
+        assert hasattr(client, "config")
+
     def test_core_client_initialization_with_config(self, sample_config):
         """Test CoreClient initializes with custom configuration."""
         client = CoreClient(config=sample_config)
         assert client is not None
-        
+
     def test_core_client_invalid_config(self):
         """Test CoreClient handles invalid configuration gracefully."""
         with pytest.raises((ValueError, TypeError)):
             CoreClient(config="invalid_config")
-            
+
     def test_core_client_none_config(self):
         """Test CoreClient handles None configuration."""
         client = CoreClient(config=None)
         assert client is not None
-        
+
     def test_process_html_valid_input(self, core_client, sample_html):
         """Test processing valid HTML content."""
         result = core_client.process_html(sample_html)
         assert result is not None
         assert isinstance(result, str)
-        
+
     def test_process_html_empty_input(self, core_client):
         """Test processing empty HTML content."""
         result = core_client.process_html("")
         assert result is not None
-        
+
     def test_process_html_none_input(self, core_client):
         """Test processing None input."""
         with pytest.raises((ValueError, TypeError)):
             core_client.process_html(None)
-            
+
     def test_process_html_malformed_html(self, core_client):
         """Test processing malformed HTML content."""
         malformed_html = "<html><body><h1>Unclosed header<p>Unclosed paragraph"
         result = core_client.process_html(malformed_html)
         assert result is not None
-        
+
     def test_process_html_with_special_characters(self, core_client):
         """Test processing HTML with special characters and encoding."""
-        special_html = "<html><body><p>Special chars: åäö, 中文, emoji 🚀</p></body></html>"
+        special_html = (
+            "<html><body><p>Special chars: åäö, 中文, emoji 🚀</p></body></html>"
+        )
         result = core_client.process_html(special_html)
         assert result is not None
         assert isinstance(result, str)
 
+
 class TestNetworkClient:
     """Test suite for NetworkClient functionality."""
-    
+
     def test_network_client_initialization(self):
         """Test NetworkClient initializes correctly."""
         client = NetworkClient()
         assert client is not None
-        
+
     def test_network_client_with_timeout(self):
         """Test NetworkClient initializes with custom timeout."""
         client = NetworkClient(timeout=60)
         assert client.timeout == 60
-        
-    @patch('requests.get')
+
+    @patch("requests.get")
     def test_fetch_url_success(self, mock_get, network_client, mock_response):
         """Test successful URL fetching."""
         mock_get.return_value = mock_response
         result = network_client.fetch_url("https://example.com")
         assert result is not None
         mock_get.assert_called_once()
-        
-    @patch('requests.get')
+
+    @patch("requests.get")
     def test_fetch_url_with_headers(self, mock_get, network_client, mock_response):
         """Test URL fetching with custom headers."""
         mock_get.return_value = mock_response
         custom_headers = {"User-Agent": "TestAgent"}
-        result = network_client.fetch_url("https://example.com", headers=custom_headers)
+        network_client.fetch_url("https://example.com", headers=custom_headers)
         mock_get.assert_called_once()
         args, kwargs = mock_get.call_args
         assert "headers" in kwargs
-        
-    @patch('requests.get')
+
+    @patch("requests.get")
     def test_fetch_url_timeout(self, mock_get, network_client):
         """Test URL fetching with timeout."""
         mock_get.side_effect = Timeout("Request timed out")
         with pytest.raises(Timeout):
             network_client.fetch_url("https://example.com")
-            
-    @patch('requests.get')
+
+    @patch("requests.get")
     def test_fetch_url_connection_error(self, mock_get, network_client):
         """Test URL fetching with connection error."""
         mock_get.side_effect = ConnectionError("Connection failed")
         with pytest.raises(ConnectionError):
             network_client.fetch_url("https://example.com")
-            
-    @patch('requests.get')
+
+    @patch("requests.get")
     def test_fetch_url_invalid_url(self, mock_get, network_client):
         """Test fetching invalid URL."""
         with pytest.raises((ValueError, RequestException)):
             network_client.fetch_url("not-a-valid-url")
-            
-    @patch('requests.get')
+
+    @patch("requests.get")
     def test_fetch_url_empty_url(self, mock_get, network_client):
         """Test fetching empty URL."""
         with pytest.raises((ValueError, RequestException)):
             network_client.fetch_url("")
-            
-    @patch('requests.get')
+
+    @patch("requests.get")
     def test_fetch_url_none_url(self, mock_get, network_client):
         """Test fetching None URL."""
         with pytest.raises((ValueError, TypeError)):
             network_client.fetch_url(None)
-            
+
     def test_core_client_large_html_input(self, core_client):
         """Test processing very large HTML input."""
         large_html = "<html><body>" + "<p>Large content</p>" * 10000 + "</body></html>"
         result = core_client.process_html(large_html)
         assert result is not None
-        
+
     def test_core_client_deeply_nested_html(self, core_client):
         """Test processing deeply nested HTML."""
         nested_html = "<html><body>"
         for i in range(100):
             nested_html += f"<div class='level-{i}'>"
         nested_html += "Deep content"
-        for i in range(100):
+        for _ in range(100):
             nested_html += "</div>"
         nested_html += "</body></html>"
         result = core_client.process_html(nested_html)
         assert result is not None
-        
-    @patch('requests.get')
+
+    @patch("requests.get")
     def test_network_client_retry_mechanism(self, mock_get, network_client):
         """Test retry mechanism on network failures."""
         mock_get.side_effect = [
             ConnectionError("First attempt failed"),
             ConnectionError("Second attempt failed"),
-            Mock(status_code=200, text="Success")
+            Mock(status_code=200, text="Success"),
         ]
-        result = network_client.fetch_url_with_retry("https://example.com", max_retries=3)
+        network_client.fetch_url_with_retry(
+            "https://example.com", max_retries=3
+        )
         assert mock_get.call_count == 3
-        
+
     def test_core_client_concurrent_processing(self, core_client, sample_html):
         """Test concurrent HTML processing."""
         import threading
+
         results = []
+
         def process_html():
             result = core_client.process_html(sample_html)
             results.append(result)
+
         threads = [threading.Thread(target=process_html) for _ in range(5)]
-        for thread in threads: thread.start()
-        for thread in threads: thread.join()
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
         assert len(results) == 5
         assert all(result is not None for result in results)
-        
-    @patch('requests.get')
-    def test_network_client_rate_limiting(self, mock_get, network_client, mock_response):
+
+    @patch("requests.get")
+    def test_network_client_rate_limiting(
+        self, mock_get, network_client, mock_response
+    ):
         """Test rate limiting behavior."""
         mock_get.return_value = mock_response
         start_time = time.time()
         for _ in range(3):
-            network_client.fetch_url_with_rate_limit("https://example.com", min_interval=0.1)
+            network_client.fetch_url_with_rate_limit(
+                "https://example.com", min_interval=0.1
+            )
         end_time = time.time()
         assert end_time - start_time >= 0.2
 
+
 class TestClientIntegration:
     """Integration tests for client interactions."""
-    
-    @patch('requests.get')
+
+    @patch("requests.get")
     def test_end_to_end_workflow(self, mock_get, mock_response):
         """Test complete workflow from URL fetch to markdown conversion."""
         mock_get.return_value = mock_response
@@ -226,17 +245,17 @@ class TestClientIntegration:
         assert html_content is not None
         assert markdown_result is not None
         mock_get.assert_called_once()
-        
+
     def test_error_propagation_workflow(self):
         """Test error propagation through client chain."""
         network_client = NetworkClient()
         core_client = CoreClient()
-        with patch('requests.get', side_effect=ConnectionError("Network error")):
+        with patch("requests.get", side_effect=ConnectionError("Network error")):
             with pytest.raises(ConnectionError):
                 html_content = network_client.fetch_url("https://example.com")
                 core_client.process_html(html_content)
-                
-    @patch('requests.get')
+
+    @patch("requests.get")
     def test_client_state_management(self, mock_get, mock_response):
         """Test client state management across multiple operations."""
         mock_get.return_value = mock_response
@@ -247,30 +266,39 @@ class TestClientIntegration:
         assert result2 is not None
         assert mock_get.call_count == 2
 
+
 class TestParametrizedScenarios:
     """Parametrized tests for comprehensive coverage."""
-    
-    @pytest.mark.parametrize("html_input,expected_type", [
-        ("<h1>Header</h1>", str),
-        ("<p>Paragraph</p>", str),
-        ("<div><span>Nested</span></div>", str),
-        ("Plain text", str),
-        ("<html></html>", str),
-    ])
+
+    @pytest.mark.parametrize(
+        "html_input,expected_type",
+        [
+            ("<h1>Header</h1>", str),
+            ("<p>Paragraph</p>", str),
+            ("<div><span>Nested</span></div>", str),
+            ("Plain text", str),
+            ("<html></html>", str),
+        ],
+    )
     def test_core_client_various_inputs(self, core_client, html_input, expected_type):
         """Test CoreClient with various HTML inputs."""
         result = core_client.process_html(html_input)
         assert isinstance(result, expected_type)
-        
-    @pytest.mark.parametrize("url,should_raise", [
-        ("https://valid-url.com", False),
-        ("http://another-valid.com", False),
-        ("invalid-url", True),
-        ("", True),
-        ("ftp://not-http.com", True),
-    ])
-    @patch('requests.get')
-    def test_network_client_url_validation(self, mock_get, network_client, mock_response, url, should_raise):
+
+    @pytest.mark.parametrize(
+        "url,should_raise",
+        [
+            ("https://valid-url.com", False),
+            ("http://another-valid.com", False),
+            ("invalid-url", True),
+            ("", True),
+            ("ftp://not-http.com", True),
+        ],
+    )
+    @patch("requests.get")
+    def test_network_client_url_validation(
+        self, mock_get, network_client, mock_response, url, should_raise
+    ):
         """Test NetworkClient URL validation."""
         mock_get.return_value = mock_response
         if should_raise:
@@ -279,20 +307,27 @@ class TestParametrizedScenarios:
         else:
             result = network_client.fetch_url(url)
             assert result is not None
-            
-    @pytest.mark.parametrize("status_code,should_raise", [
-        (200, False),
-        (201, False),
-        (404, True),
-        (500, True),
-        (403, True),
-    ])
-    @patch('requests.get')
-    def test_network_client_status_codes(self, mock_get, network_client, status_code, should_raise):
+
+    @pytest.mark.parametrize(
+        "status_code,should_raise",
+        [
+            (200, False),
+            (201, False),
+            (404, True),
+            (500, True),
+            (403, True),
+        ],
+    )
+    @patch("requests.get")
+    def test_network_client_status_codes(
+        self, mock_get, network_client, status_code, should_raise
+    ):
         """Test NetworkClient handling of various HTTP status codes."""
         mock_resp = Mock()
         mock_resp.status_code = status_code
-        mock_resp.raise_for_status.side_effect = None if status_code < 400 else RequestException(f"HTTP {status_code}")
+        mock_resp.raise_for_status.side_effect = (
+            None if status_code < 400 else RequestException(f"HTTP {status_code}")
+        )
         mock_get.return_value = mock_resp
         if should_raise:
             with pytest.raises(RequestException):
@@ -301,16 +336,16 @@ class TestParametrizedScenarios:
             result = network_client.fetch_url("https://example.com")
             assert result is not None
 
+
 class TestClientUtilities:
     """Test utility methods and edge cases."""
-    
+
     def test_client_cleanup_resources(self, network_client):
         """Test proper resource cleanup."""
         network_client.fetch_url("https://example.com")
-        if hasattr(network_client, 'cleanup'):
+        if hasattr(network_client, "cleanup"):
             network_client.cleanup()
-        assert True
-        
+
     def test_client_configuration_validation(self):
         """Test client configuration validation."""
         valid_configs = [
@@ -321,36 +356,40 @@ class TestClientUtilities:
         for config in valid_configs:
             client = NetworkClient(**config)
             assert client is not None
-            
+
     def test_client_memory_usage(self, core_client, sample_html):
         """Test memory usage with large inputs."""
         import sys
+
         initial_size = sys.getsizeof(core_client)
         for _ in range(10):
             large_html = sample_html * 1000
             core_client.process_html(large_html)
         final_size = sys.getsizeof(core_client)
         assert final_size - initial_size < 1000000
-        
+
     def teardown_method(self, method):
         """Clean up after each test method."""
         pass
-        
+
     @classmethod
     def teardown_class(cls):
         """Clean up after all tests in class."""
         pass
 
+
 class TestClientPerformance:
     """Performance benchmarks for client operations."""
-    
+
     def test_core_client_performance(self, benchmark, core_client, sample_html):
         """Benchmark CoreClient HTML processing performance."""
         result = benchmark(core_client.process_html, sample_html)
         assert result is not None
-        
-    @patch('requests.get')
-    def test_network_client_performance(self, benchmark, mock_get, network_client, mock_response):
+
+    @patch("requests.get")
+    def test_network_client_performance(
+        self, benchmark, mock_get, network_client, mock_response
+    ):
         """Benchmark NetworkClient URL fetching performance."""
         mock_get.return_value = mock_response
         result = benchmark(network_client.fetch_url, "https://example.com")

--- a/tests/unit/test_rust_backend.py
+++ b/tests/unit/test_rust_backend.py
@@ -1,17 +1,16 @@
 """Comprehensive unit tests for rust_backend module."""
-import pytest
-import unittest.mock as mock
-from unittest.mock import patch, MagicMock, call, Mock
-import tempfile
+
 import os
-import sys
 import subprocess
-import json
+import sys
+import tempfile
 from pathlib import Path
-from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 # Add the project root to Python path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 # Import the module under test
 try:
@@ -24,7 +23,10 @@ except ImportError:
 
 # Import any custom exceptions
 try:
-    from git.markdown_lab.core.rust_backend import RustBackendError, RustCompilationError
+    from git.markdown_lab.core.rust_backend import (
+        RustBackendError,
+        RustCompilationError,
+    )
 except ImportError:
     # Define mock exceptions if they don't exist
     class RustBackendError(Exception):
@@ -44,7 +46,7 @@ def temp_dir():
 @pytest.fixture
 def mock_subprocess():
     """Mock subprocess module for testing."""
-    with patch('subprocess.run') as mock_run:
+    with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         yield mock_run
 
@@ -59,34 +61,34 @@ def sample_rust_config():
         "optimization_level": "2",
         "debug": False,
         "features": [],
-        "output_dir": "/tmp/rust_output"
+        "output_dir": "/tmp/rust_output",
     }
 
 
 @pytest.fixture
 def simple_rust_code():
     """Provide simple valid Rust source code for testing."""
-    return '''
+    return """
 fn main() {
     println!("Hello, world!");
 }
-'''
+"""
 
 
 @pytest.fixture
 def invalid_rust_code():
     """Provide invalid Rust source code for error testing."""
-    return '''
+    return """
 fn main() {
     println!("Hello, world!")  // Missing semicolon
 }
-'''
+"""
 
 
 @pytest.fixture
 def rust_backend_instance(sample_rust_config):
     """Create a RustBackend instance for testing."""
-    with patch('subprocess.run'):
+    with patch("subprocess.run"):
         return RustBackend(sample_rust_config)
 
 
@@ -95,18 +97,20 @@ class TestRustBackendInitialization:
 
     def test_init_with_valid_config(self, sample_rust_config):
         """Test successful initialization with valid configuration."""
-        with patch('subprocess.run'):
+        with patch("subprocess.run"):
             backend = RustBackend(sample_rust_config)
-            assert hasattr(backend, 'config')
+            assert hasattr(backend, "config")
             for key, value in sample_rust_config.items():
-                assert getattr(backend, key, None) == value or key in str(backend.config)
+                assert getattr(backend, key, None) == value or key in str(
+                    backend.config
+                )
 
     def test_init_with_minimal_config(self):
         """Test initialization with minimal configuration."""
         minimal_config = {"rust_path": "/usr/bin/rustc"}
-        with patch('subprocess.run'):
+        with patch("subprocess.run"):
             backend = RustBackend(minimal_config)
-            assert hasattr(backend, 'config')
+            assert hasattr(backend, "config")
 
     def test_init_with_empty_config(self):
         """Test initialization with empty configuration raises appropriate error."""
@@ -123,13 +127,9 @@ class TestRustBackendInitialization:
         with pytest.raises((TypeError, AttributeError)):
             RustBackend("invalid_config")
 
-    @pytest.mark.parametrize("invalid_path", [
-        "/nonexistent/path/rustc",
-        "",
-        None,
-        123,
-        []
-    ])
+    @pytest.mark.parametrize(
+        "invalid_path", ["/nonexistent/path/rustc", "", None, 123, []]
+    )
     def test_init_with_invalid_rust_path(self, invalid_path, sample_rust_config):
         """Test initialization with various invalid rust paths."""
         sample_rust_config["rust_path"] = invalid_path
@@ -140,35 +140,41 @@ class TestRustBackendInitialization:
 class TestRustBackendCompilation:
     """Test RustBackend compilation methods."""
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_compile_success(self, mock_run, rust_backend_instance, simple_rust_code):
         """Test successful compilation with valid Rust code."""
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout="Compiling test_program...\nFinished release [optimized] target(s)",
-            stderr=""
+            stderr="",
         )
 
-        result = rust_backend_instance.compile(simple_rust_code, "test_program")
+        rust_backend_instance.compile(simple_rust_code, "test_program")
 
         mock_run.assert_called_once()
         call_args = mock_run.call_args[0][0] if mock_run.call_args else []
         assert any("rustc" in str(arg) or "cargo" in str(arg) for arg in call_args)
 
-    @patch('subprocess.run')
-    def test_compile_failure_syntax_error(self, mock_run, rust_backend_instance, invalid_rust_code):
+    @patch("subprocess.run")
+    def test_compile_failure_syntax_error(
+        self, mock_run, rust_backend_instance, invalid_rust_code
+    ):
         """Test compilation failure with syntax errors."""
         mock_run.return_value = MagicMock(
             returncode=1,
             stdout="",
-            stderr="error: expected `;`, found `}`\n  --> src/main.rs:3:35"
+            stderr="error: expected `;`, found `}`\n  --> src/main.rs:3:35",
         )
 
-        with pytest.raises((RustCompilationError, subprocess.CalledProcessError, Exception)):
+        with pytest.raises(
+            (RustCompilationError, subprocess.CalledProcessError, Exception)
+        ):
             rust_backend_instance.compile(invalid_rust_code, "test_program")
 
-    @patch('subprocess.run')
-    def test_compile_with_optimization_levels(self, mock_run, sample_rust_config, simple_rust_code):
+    @patch("subprocess.run")
+    def test_compile_with_optimization_levels(
+        self, mock_run, sample_rust_config, simple_rust_code
+    ):
         """Test compilation with different optimization levels."""
         optimization_levels = ["0", "1", "2", "3", "s", "z"]
 
@@ -196,7 +202,9 @@ class TestRustBackendCompilation:
             rust_backend_instance.compile("   \n\t  \n  ", "test_program")
 
     @pytest.mark.parametrize("invalid_name", ["", None, 123, [], {}])
-    def test_compile_invalid_program_name(self, rust_backend_instance, simple_rust_code, invalid_name):
+    def test_compile_invalid_program_name(
+        self, rust_backend_instance, simple_rust_code, invalid_name
+    ):
         """Test compilation with invalid program names."""
         with pytest.raises((ValueError, TypeError, RustBackendError)):
             rust_backend_instance.compile(simple_rust_code, invalid_name)
@@ -205,31 +213,37 @@ class TestRustBackendCompilation:
 class TestRustBackendErrorHandling:
     """Test RustBackend error handling scenarios."""
 
-    @patch('subprocess.run')
-    def test_subprocess_timeout(self, mock_run, rust_backend_instance, simple_rust_code):
+    @patch("subprocess.run")
+    def test_subprocess_timeout(
+        self, mock_run, rust_backend_instance, simple_rust_code
+    ):
         """Test handling of compilation timeout."""
         mock_run.side_effect = subprocess.TimeoutExpired("rustc", 30)
 
         with pytest.raises((subprocess.TimeoutExpired, RustBackendError)):
             rust_backend_instance.compile(simple_rust_code, "test_timeout")
 
-    @patch('subprocess.run')
-    def test_subprocess_permission_error(self, mock_run, rust_backend_instance, simple_rust_code):
+    @patch("subprocess.run")
+    def test_subprocess_permission_error(
+        self, mock_run, rust_backend_instance, simple_rust_code
+    ):
         """Test handling of permission errors during compilation."""
         mock_run.side_effect = PermissionError("Permission denied: rustc")
 
         with pytest.raises((PermissionError, RustBackendError)):
             rust_backend_instance.compile(simple_rust_code, "test_permission")
 
-    @patch('subprocess.run')
-    def test_subprocess_file_not_found(self, mock_run, rust_backend_instance, simple_rust_code):
+    @patch("subprocess.run")
+    def test_subprocess_file_not_found(
+        self, mock_run, rust_backend_instance, simple_rust_code
+    ):
         """Test handling when rust compiler is not found."""
         mock_run.side_effect = FileNotFoundError("rustc: command not found")
 
         with pytest.raises((FileNotFoundError, RustBackendError)):
             rust_backend_instance.compile(simple_rust_code, "test_not_found")
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_compilation_memory_error(self, mock_run, rust_backend_instance):
         """Test handling of memory-intensive compilation."""
         large_code = "fn main() {\n" + "    let x = 42;\n" * 10000 + "}\n"
@@ -238,32 +252,41 @@ class TestRustBackendErrorHandling:
         with pytest.raises((MemoryError, RustBackendError)):
             rust_backend_instance.compile(large_code, "test_memory")
 
-    @patch('subprocess.run')
-    def test_rust_compiler_crash(self, mock_run, rust_backend_instance, simple_rust_code):
+    @patch("subprocess.run")
+    def test_rust_compiler_crash(
+        self, mock_run, rust_backend_instance, simple_rust_code
+    ):
         """Test handling when rust compiler crashes with high return code."""
         mock_run.return_value = MagicMock(
             returncode=101,
             stdout="",
-            stderr="internal compiler error: compiler crashed"
+            stderr="internal compiler error: compiler crashed",
         )
 
-        with pytest.raises((RustCompilationError, subprocess.CalledProcessError, Exception)):
+        with pytest.raises(
+            (RustCompilationError, subprocess.CalledProcessError, Exception)
+        ):
             rust_backend_instance.compile(simple_rust_code, "test_crash")
 
 
 class TestRustBackendParameterized:
     """Parameterized tests for comprehensive coverage."""
 
-    @pytest.mark.parametrize("target", [
-        "x86_64-unknown-linux-gnu",
-        "aarch64-unknown-linux-gnu",
-        "x86_64-pc-windows-msvc",
-        "x86_64-apple-darwin",
-        "wasm32-unknown-unknown",
-        "thumbv7em-none-eabihf"
-    ])
-    @patch('subprocess.run')
-    def test_compile_different_targets(self, mock_run, target, sample_rust_config, simple_rust_code):
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "x86_64-unknown-linux-gnu",
+            "aarch64-unknown-linux-gnu",
+            "x86_64-pc-windows-msvc",
+            "x86_64-apple-darwin",
+            "wasm32-unknown-unknown",
+            "thumbv7em-none-eabihf",
+        ],
+    )
+    @patch("subprocess.run")
+    def test_compile_different_targets(
+        self, mock_run, target, sample_rust_config, simple_rust_code
+    ):
         """Test compilation for different target architectures."""
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
@@ -276,15 +299,14 @@ class TestRustBackendParameterized:
         call_args = str(mock_run.call_args)
         assert target in call_args or "--target" in call_args
 
-    @pytest.mark.parametrize("feature_set", [
-        [],
-        ["serde"],
-        ["serde", "tokio"],
-        ["default", "extra-traits"],
-        ["full"]
-    ])
-    @patch('subprocess.run')
-    def test_compile_with_features(self, mock_run, feature_set, sample_rust_config, simple_rust_code):
+    @pytest.mark.parametrize(
+        "feature_set",
+        [[], ["serde"], ["serde", "tokio"], ["default", "extra-traits"], ["full"]],
+    )
+    @patch("subprocess.run")
+    def test_compile_with_features(
+        self, mock_run, feature_set, sample_rust_config, simple_rust_code
+    ):
         """Test compilation with different feature sets."""
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
@@ -296,59 +318,65 @@ class TestRustBackendParameterized:
         mock_run.assert_called()
         if feature_set:
             call_args = str(mock_run.call_args)
-            assert "--features" in call_args or any(feature in call_args for feature in feature_set)
+            assert "--features" in call_args or any(
+                feature in call_args for feature in feature_set
+            )
 
-    @pytest.mark.parametrize("source_variant", [
-        "fn main() { println!(\"Hello\"); }",
-        "fn main() {\n    let x = 42;\n    println!(\"{}\", x);\n}",
-        "use std::collections::HashMap;\nfn main() { let _map = HashMap::new(); }",
-        "#[derive(Debug)]\nstruct Point { x: i32, y: i32 }\nfn main() { let _p = Point { x: 1, y: 2 }; }"
-    ])
-    @patch('subprocess.run')
-    def test_compile_various_source_patterns(self, mock_run, source_variant, rust_backend_instance):
+    @pytest.mark.parametrize(
+        "source_variant",
+        [
+            'fn main() { println!("Hello"); }',
+            'fn main() {\n    let x = 42;\n    println!("{}", x);\n}',
+            "use std::collections::HashMap;\nfn main() { let _map = HashMap::new(); }",
+            "#[derive(Debug)]\nstruct Point { x: i32, y: i32 }\nfn main() { let _p = Point { x: 1, y: 2 }; }",
+        ],
+    )
+    @patch("subprocess.run")
+    def test_compile_various_source_patterns(
+        self, mock_run, source_variant, rust_backend_instance
+    ):
         """Test compilation with various valid Rust source code patterns."""
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
-        result = rust_backend_instance.compile(source_variant, "test_variant")
+        rust_backend_instance.compile(source_variant, "test_variant")
         mock_run.assert_called()
 
 
 class TestRustBackendUtilities:
     """Test utility methods and helper functions."""
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_get_rust_version(self, mock_run, rust_backend_instance):
         """Test retrieving Rust compiler version."""
         mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="rustc 1.70.0 (90c541806 2023-05-31)\nbinary: rustc"
+            returncode=0, stdout="rustc 1.70.0 (90c541806 2023-05-31)\nbinary: rustc"
         )
 
-        if hasattr(rust_backend_instance, 'get_rust_version'):
+        if hasattr(rust_backend_instance, "get_rust_version"):
             version = rust_backend_instance.get_rust_version()
             assert "1.70.0" in version
         else:
             rust_backend_instance.compile("fn main() {}", "version_test")
             mock_run.assert_called()
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_list_available_targets(self, mock_run, rust_backend_instance):
         """Test listing available compilation targets."""
         mock_targets = "x86_64-unknown-linux-gnu\naarch64-unknown-linux-gnu\nx86_64-pc-windows-msvc"
         mock_run.return_value = MagicMock(returncode=0, stdout=mock_targets)
 
-        if hasattr(rust_backend_instance, 'list_targets'):
+        if hasattr(rust_backend_instance, "list_targets"):
             targets = rust_backend_instance.list_targets()
             assert "x86_64-unknown-linux-gnu" in targets
             assert "aarch64-unknown-linux-gnu" in targets
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_validate_configuration(self, mock_run, sample_rust_config):
         """Test configuration validation."""
         mock_run.return_value = MagicMock(returncode=0)
 
         backend = RustBackend(sample_rust_config)
-        if hasattr(backend, 'validate_config'):
+        if hasattr(backend, "validate_config"):
             assert backend.validate_config() is True
 
         invalid_config = sample_rust_config.copy()
@@ -361,10 +389,10 @@ class TestRustBackendUtilities:
         temp_file = temp_dir / "test.rs"
         temp_file.write_text("fn main() {}")
 
-        if hasattr(rust_backend_instance, 'cleanup'):
+        if hasattr(rust_backend_instance, "cleanup"):
             rust_backend_instance.cleanup()
 
-        if hasattr(rust_backend_instance, '__enter__'):
+        if hasattr(rust_backend_instance, "__enter__"):
             with rust_backend_instance:
                 pass
 
@@ -372,30 +400,30 @@ class TestRustBackendUtilities:
 class TestRustBackendIntegration:
     """Integration tests for complete workflows."""
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_complete_build_workflow(self, mock_run, temp_dir, sample_rust_config):
         """Test complete build workflow from source to executable."""
         mock_run.return_value = MagicMock(returncode=0, stdout="Build successful")
 
         backend = RustBackend(sample_rust_config)
 
-        source_code = '''
+        source_code = """
 use std::env;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
     println!("Hello from Rust! Args: {:?}", args);
 }
-'''
+"""
 
-        result = backend.compile(source_code, "integration_test")
+        backend.compile(source_code, "integration_test")
         mock_run.assert_called()
 
-        if hasattr(backend, 'get_build_artifacts'):
+        if hasattr(backend, "get_build_artifacts"):
             artifacts = backend.get_build_artifacts()
             assert len(artifacts) >= 0
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_error_recovery_workflow(self, mock_run, rust_backend_instance):
         """Test error recovery and retry mechanisms."""
         mock_run.return_value = MagicMock(returncode=1, stderr="temporary error")
@@ -403,10 +431,12 @@ fn main() {
             rust_backend_instance.compile("fn main() {}", "retry_test")
 
         mock_run.return_value = MagicMock(returncode=0, stdout="success")
-        if hasattr(rust_backend_instance, 'retry_compilation'):
-            result = rust_backend_instance.retry_compilation("fn main() {}", "retry_test")
+        if hasattr(rust_backend_instance, "retry_compilation"):
+            rust_backend_instance.retry_compilation(
+                "fn main() {}", "retry_test"
+            )
         else:
-            result = rust_backend_instance.compile("fn main() {}", "retry_test2")
+            rust_backend_instance.compile("fn main() {}", "retry_test2")
 
 
 @pytest.mark.slow
@@ -414,22 +444,23 @@ class TestRustBackendStress:
     """Stress tests and performance-related tests."""
 
     @pytest.mark.parametrize("code_size", [100, 1000, 5000])
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_large_source_compilation(self, mock_run, code_size, rust_backend_instance):
         """Test compilation with large source files."""
         mock_run.return_value = MagicMock(returncode=0)
 
         large_code = "fn main() {\n"
         large_code += "    let mut sum = 0;\n" * code_size
-        large_code += "    println!(\"Sum: {}\", sum);\n}\n"
+        large_code += '    println!("Sum: {}", sum);\n}\n'
 
-        result = rust_backend_instance.compile(large_code, f"large_test_{code_size}")
+        rust_backend_instance.compile(large_code, f"large_test_{code_size}")
         mock_run.assert_called()
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_concurrent_compilation_safety(self, mock_run, rust_backend_instance):
         """Test thread safety during concurrent operations."""
         import threading
+
         mock_run.return_value = MagicMock(returncode=0)
 
         results = []
@@ -437,7 +468,7 @@ class TestRustBackendStress:
 
         def compile_worker(worker_id):
             try:
-                code = f"fn main() {{ println!(\"Worker {worker_id}\"); }}"
+                code = f'fn main() {{ println!("Worker {worker_id}"); }}'
                 result = rust_backend_instance.compile(code, f"worker_{worker_id}")
                 results.append(result)
             except Exception as e:
@@ -449,23 +480,30 @@ class TestRustBackendStress:
         for thread in threads:
             thread.join()
 
-        assert len(errors) == 0 or all(isinstance(e, (RustBackendError, Exception)) for e in errors)
+        assert not errors or all(
+            isinstance(e, (RustBackendError, Exception)) for e in errors
+        )
 
 
 class TestRustBackendEdgeCases:
     """Test edge cases and boundary conditions."""
 
-    @pytest.mark.parametrize("special_chars", [
-        "fn main() { println!(\"Hello 世界\"); }",
-        "fn main() { println!(\"Quote: \\\"test\\\"\"); }",
-        "fn main() { println!(r#\"Raw string\"#); }",
-    ])
-    @patch('subprocess.run')
-    def test_special_character_handling(self, mock_run, special_chars, rust_backend_instance):
+    @pytest.mark.parametrize(
+        "special_chars",
+        [
+            'fn main() { println!("Hello 世界"); }',
+            'fn main() { println!("Quote: \\"test\\""); }',
+            'fn main() { println!(r#"Raw string"#); }',
+        ],
+    )
+    @patch("subprocess.run")
+    def test_special_character_handling(
+        self, mock_run, special_chars, rust_backend_instance
+    ):
         """Test handling of special characters in source code."""
         mock_run.return_value = MagicMock(returncode=0)
 
-        result = rust_backend_instance.compile(special_chars, "special_chars_test")
+        rust_backend_instance.compile(special_chars, "special_chars_test")
         mock_run.assert_called()
 
     def test_configuration_edge_cases(self, sample_rust_config):
@@ -478,7 +516,7 @@ class TestRustBackendEdgeCases:
 
         for config in edge_cases:
             try:
-                with patch('subprocess.run'):
+                with patch("subprocess.run"):
                     backend = RustBackend(config)
                     assert backend is not None
             except (ValueError, TypeError, RustBackendError):
@@ -488,10 +526,9 @@ class TestRustBackendEdgeCases:
 def test_module_imports():
     """Test that all required modules can be imported."""
     try:
+        import pathlib
         import subprocess
         import tempfile
-        import pathlib
-        assert True
     except ImportError as e:
         pytest.fail(f"Required module import failed: {e}")
 
@@ -499,7 +536,7 @@ def test_module_imports():
 def test_rust_backend_class_exists():
     """Test that RustBackend class exists and is instantiable."""
     try:
-        with patch('subprocess.run'):
+        with patch("subprocess.run"):
             RustBackend({"rust_path": "/usr/bin/rustc"})
     except (TypeError, ValueError, RustBackendError):
         pass
@@ -509,11 +546,9 @@ def test_rust_backend_class_exists():
 
 def test_rust_backend_has_docstrings():
     """Test that RustBackend class and methods have proper documentation."""
-    if hasattr(RustBackend, '__doc__'):
+    if hasattr(RustBackend, "__doc__"):
         assert RustBackend.__doc__ is not None
 
-    for method_name in ['compile', '__init__']:
+    for method_name in ["compile", "__init__"]:
         if hasattr(RustBackend, method_name):
-            method = getattr(RustBackend, method_name)
-            if hasattr(method, '__doc__'):
-                pass
+            getattr(RustBackend, method_name)


### PR DESCRIPTION
This pull request focuses on improving code readability and consistency in the `tests/rust/test_rust_backend.py` file by standardizing string delimiters, formatting, and fixture definitions. Additionally, it includes minor changes to the `benches/markdown_bench.rs` file to reorder imports for better organization.

### Code readability and consistency improvements:

* **String delimiters standardized:** All single-quoted strings were replaced with double-quoted strings to ensure consistency across the test suite. This change affects various test cases and fixture definitions (`tests/rust/test_rust_backend.py`). [[1]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28L1-R61) [[2]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28L87-R93) [[3]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28R104) [[4]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28R114-R123) [[5]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28L130-R198) [[6]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28L184-R207) [[7]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28L202-R225) [[8]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28L237-R269) [[9]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28L270-R327) [[10]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28L310-R381) [[11]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28L356-R458) [[12]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28L413-R529)

* **Fixture definitions reformatted:** Multi-line fixture definitions and test cases now use consistent indentation and formatting for improved readability (`tests/rust/test_rust_backend.py`). [[1]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28L130-R198) [[2]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28L237-R269) [[3]](diffhunk://#diff-d534b3a334b720962c59445f8137e059c0850a1b23378fa60cb5dde657614a28L413-R529)

### Minor import organization:

* **Reordered imports:** Adjusted the order of imports in `benches/markdown_bench.rs` for better organization and adherence to Rust conventions.

@Claude please review